### PR TITLE
implemented lazy downloading

### DIFF
--- a/ultimate-pipeline/notebooks/data_processing.ipynb
+++ b/ultimate-pipeline/notebooks/data_processing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,19 +24,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[DatasetInfo(id=924169, name='mini_test_set', description='', size='30069932', project_id=290921, images_count=5, items_count=5, created_at='2024-03-04T11:55:42.197Z', updated_at='2024-03-04T12:43:50.688Z', reference_image_url='/image-converter/convert/h5un6l2bnaz1vj8a9qgms4-public/images/original/Q/W/Tk/7Jbgysq2DUgluNGrCyjy8OSa8WpD67TB91skInbOAlOPyrhdh1TNQZl02ygDtVNIhbGnPvJCbqFEzlDoyKFoiI1GllNIaPfG4nljE0v0qDp6zMWKHLl7vIJPpxAr.jpg', team_id=85138, workspace_id=99292),\n",
-       " DatasetInfo(id=924250, name='set_0000_0099', description='', size='271133980', project_id=290921, images_count=100, items_count=100, created_at='2024-03-04T22:31:15.146Z', updated_at='2024-03-05T09:00:06.026Z', reference_image_url='/image-converter/convert/h5un6l2bnaz1vj8a9qgms4-public/images/original/Q/W/Tk/7Jbgysq2DUgluNGrCyjy8OSa8WpD67TB91skInbOAlOPyrhdh1TNQZl02ygDtVNIhbGnPvJCbqFEzlDoyKFoiI1GllNIaPfG4nljE0v0qDp6zMWKHLl7vIJPpxAr.jpg', team_id=85138, workspace_id=99292)]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'supervisely.api.image_api.ImageInfo'>\n",
+      "<class 'supervisely.api.image_api.ImageInfo'>\n",
+      "<class 'supervisely.api.image_api.ImageInfo'>\n",
+      "<class 'supervisely.api.image_api.ImageInfo'>\n",
+      "<class 'supervisely.api.image_api.ImageInfo'>\n"
+     ]
     }
    ],
    "source": [
@@ -44,7 +44,10 @@
     "\n",
     "api.dataset.get_list(290921)\n",
     "\n",
-    "#image_info_list = api.image.get_list(924169)\n",
+    "image_info_list = api.image.get_list(924169)\n",
+    "\n",
+    "for image in image_info_list:\n",
+    "    print(type(image))\n",
     "#api.annotation.download(image_info_list[0].id).annotation\n",
     "\n",
     "    \n"

--- a/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
+++ b/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
@@ -8,6 +8,7 @@ import logging
 from dotenv import load_dotenv
 from PIL import Image
 from pathlib import Path
+from functools import partial
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,17 @@ def helper_download_image_dataset_from_supervisely(params: t.Dict) -> t.Tuple[t.
             - annotations_dict: A dictionary containing the annotations for each image
             - images_dict: A dictionary containing the images
     """
+
+    def download_image(img: sly.api.image_api.ImageInfo, api:sly.api) -> np.ndarray:
+        """ Download image from Supervisely """
+        logger.info(f"Start downloading image {img.name} from Supervisely")
+        return Image.fromarray(api.image.download_np(img.id))
     
+    def download_annotation(img: sly.api.image_api.ImageInfo, api:sly.api)-> t.Dict[str, t.Any]:
+        """ Download annotation from Supervisely """
+        logger.info(f"Start downloading annotation for image {img.name} from Supervisely")
+        return api.annotation.download(img.id).annotation
+
     if sly.is_development():
         load_dotenv(os.path.expanduser("~/supervisely.env"))
 
@@ -39,42 +50,8 @@ def helper_download_image_dataset_from_supervisely(params: t.Dict) -> t.Tuple[t.
     images_dict = {}
 
     for image in image_info_list:
-
         image_name = Path(image.name).stem
-
-        images_dict[image_name] = download_image_lazy(image, api)
-        annotations_dict[image.name] = download_annotation_lazy(image, api)
+        images_dict[image_name] = partial(download_image, image, api)
+        annotations_dict[image.name] = partial(download_annotation, image, api)
 
     return metadata, annotations_dict, images_dict
-
-
-def download_image_lazy(image: sly.api.image_api.ImageInfo, api: sly.api):
-    """ Download image from Supervisely lazily
-    
-        Args: 
-            image: The image to download
-            api: The Supervisely API
-        Returns:
-            A function that downloads the image
-    """
-    def download_image() -> np.ndarray:
-        logger.info(f"Start downloading image {image.name} from Supervisely")
-        return Image.fromarray(api.image.download_np(image.id))
-    
-    return download_image
-
-
-def download_annotation_lazy(image: sly.api.image_api.ImageInfo, api: sly.api) -> t.Callable[[], np.ndarray]:
-    """ Download annotation from Supervisely lazily
-    
-        Args: 
-            image: image for which the annotation should be downloaded
-            api: The Supervisely API
-        Returns:
-            A function that downloads the annotation
-    """
-    def download_annotation()-> t.Dict[str, t.Any]:
-        logger.info(f"Start downloading annotation for image {image.name} from Supervisely")
-        return api.annotation.download(image.id).annotation
-    
-    return download_annotation

--- a/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
+++ b/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
@@ -1,5 +1,6 @@
 import supervisely as sly
 import typing as t
+import numpy as np
 
 import os
 import logging
@@ -56,7 +57,7 @@ def download_image_lazy(image: sly.api.image_api.ImageInfo, api: sly.api):
         Returns:
             A function that downloads the image
     """
-    def download_image():
+    def download_image() -> np.ndarray:
         logger.info(f"Start downloading image {image.name} from Supervisely")
         return Image.fromarray(api.image.download_np(image.id))
     
@@ -67,12 +68,12 @@ def download_annotation_lazy(image: sly.api.image_api.ImageInfo, api: sly.api):
     """ Download annotation from Supervisely lazily
     
         Args: 
-            annotation: The annotation to download
+            image: image for which the annotation should be downloaded
             api: The Supervisely API
         Returns:
             A function that downloads the annotation
     """
-    def download_annotation():
+    def download_annotation()-> t.Dict[str, t.Any]:
         logger.info(f"Start downloading annotation for image {image.name} from Supervisely")
         return api.annotation.download(image.id).annotation
     

--- a/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
+++ b/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
@@ -64,7 +64,7 @@ def download_image_lazy(image: sly.api.image_api.ImageInfo, api: sly.api):
     return download_image
 
 
-def download_annotation_lazy(image: sly.api.image_api.ImageInfo, api: sly.api):
+def download_annotation_lazy(image: sly.api.image_api.ImageInfo, api: sly.api) -> t.Callable[[], np.ndarray]:
     """ Download annotation from Supervisely lazily
     
         Args: 


### PR DESCRIPTION
# Summary
- old download function was badly implemented because it returned a dict {filename: image data:np.array}. For big datasets this might overflow RAM because the entire dataset must be stored

# Fix:

- Implementation of lazy saving. Now the downloading function returns a dict {filename: downloader : function}. Now the data will be download one by one and stored immediately.

@adamjasinski I created a new branch to implement this. Is this good practice or not? Or should i have use  the old image_download branch?