### PR TITLE
implement multidataset download

### DIFF
--- a/ultimate-pipeline/conf/base/parameters_data_processing.yml
+++ b/ultimate-pipeline/conf/base/parameters_data_processing.yml
@@ -6,7 +6,10 @@
 
 image_dataset:
   project_id: 290921
-  dataset_id: 924169 # mini_test_set [set_0000_0099: 924250]
+  dataset_ids: 
+    #- 924169 # mini_test_set 
+    - 924250 # set_0000_0099 
+    - 927852 # set_0400_0499
 
 ultimate_object_detect:
   train_split: 0.8      # data percentage used for training

--- a/ultimate-pipeline/notebooks/data_processing.ipynb
+++ b/ultimate-pipeline/notebooks/data_processing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,15 +28,16 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'supervisely.api.image_api.ImageInfo'>\n",
-      "<class 'supervisely.api.image_api.ImageInfo'>\n",
-      "<class 'supervisely.api.image_api.ImageInfo'>\n",
-      "<class 'supervisely.api.image_api.ImageInfo'>\n",
-      "<class 'supervisely.api.image_api.ImageInfo'>\n"
-     ]
+     "data": {
+      "text/plain": [
+       "[DatasetInfo(id=924169, name='mini_test_set', description='', size='30069932', project_id=290921, images_count=5, items_count=5, created_at='2024-03-04T11:55:42.197Z', updated_at='2024-03-04T12:43:50.688Z', reference_image_url='/image-converter/convert/h5un6l2bnaz1vj8a9qgms4-public/images/original/Q/W/Tk/7Jbgysq2DUgluNGrCyjy8OSa8WpD67TB91skInbOAlOPyrhdh1TNQZl02ygDtVNIhbGnPvJCbqFEzlDoyKFoiI1GllNIaPfG4nljE0v0qDp6zMWKHLl7vIJPpxAr.jpg', team_id=85138, workspace_id=99292),\n",
+       " DatasetInfo(id=924250, name='set_0000_0099', description='', size='271133980', project_id=290921, images_count=100, items_count=100, created_at='2024-03-04T22:31:15.146Z', updated_at='2024-03-05T09:00:06.026Z', reference_image_url='/image-converter/convert/h5un6l2bnaz1vj8a9qgms4-public/images/original/Q/W/Tk/7Jbgysq2DUgluNGrCyjy8OSa8WpD67TB91skInbOAlOPyrhdh1TNQZl02ygDtVNIhbGnPvJCbqFEzlDoyKFoiI1GllNIaPfG4nljE0v0qDp6zMWKHLl7vIJPpxAr.jpg', team_id=85138, workspace_id=99292),\n",
+       " DatasetInfo(id=927852, name='set_0400_0499', description='', size='340095748', project_id=290921, images_count=100, items_count=100, created_at='2024-03-19T17:48:30.267Z', updated_at='2024-03-19T17:48:30.267Z', reference_image_url='/image-converter/convert/h5un6l2bnaz1vj8a9qgms4-public/images/original/O/M/1x/1em0raRpMKtR4OLwIxYKTW5WSLRFkD1nExgRQQeLnWc0vQfgnkyUtb3ofQIGoZuOVQ940cLPxKP3lg3LZLcF2ilciNAYGqNqdsV5IkMGYo3ovX0IMKxml1BrnmJt.jpg', team_id=85138, workspace_id=99292)]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -44,10 +45,10 @@
     "\n",
     "api.dataset.get_list(290921)\n",
     "\n",
-    "image_info_list = api.image.get_list(924169)\n",
+    "#image_info_list = api.image.get_list(924169)\n",
     "\n",
-    "for image in image_info_list:\n",
-    "    print(type(image))\n",
+    "#for image in image_info_list:\n",
+    "#    print(type(image))\n",
     "#api.annotation.download(image_info_list[0].id).annotation\n",
     "\n",
     "    \n"

--- a/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
+++ b/ultimate-pipeline/src/ultimate_pipeline/pipelines/data_processing/supervisely_downloader.py
@@ -44,14 +44,16 @@ def helper_download_image_dataset_from_supervisely(params: t.Dict) -> t.Tuple[t.
 
     metadata = api.project.get_meta(params["project_id"])
 
-    image_info_list = api.image.get_list(params["dataset_id"])
-
     annotations_dict = {}
     images_dict = {}
 
-    for image in image_info_list:
-        image_name = Path(image.name).stem
-        images_dict[image_name] = partial(download_image, image, api)
-        annotations_dict[image.name] = partial(download_annotation, image, api)
+    for dataset_id in params["dataset_ids"]:
+        
+        image_info_list = api.image.get_list(dataset_id)
+
+        for image in image_info_list:
+            image_name = Path(image.name).stem
+            images_dict[image_name] = partial(download_image, image, api)
+            annotations_dict[image.name] = partial(download_annotation, image, api)
 
     return metadata, annotations_dict, images_dict


### PR DESCRIPTION
# Summary

- in dataset_preprocessing multiple datasets can now be listed [dataset_ids]
- images and annotations from all listed datasets will then be combined into one dict and save to defined raw/... folder

PS: Now we have 200 annotated images to work with. My plan is to annotate another 100 images from the 3rd game. So we will finally have a database of 300 images randomly sampled from 3 different games.